### PR TITLE
Relax dependency on bundler

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -33,11 +33,11 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  bundler (~> 1.16)
+  bundler
   geokit-geocoder-mappify!
   pry (~> 0.11)
   rake (~> 13.0)
   rspec (~> 3.0)
 
 BUNDLED WITH
-   1.16.1
+   1.17.3

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -33,7 +33,6 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  bundler
   geokit-geocoder-mappify!
   pry (~> 0.11)
   rake (~> 13.0)

--- a/geokit-geocoder-mappify.gemspec
+++ b/geokit-geocoder-mappify.gemspec
@@ -21,7 +21,6 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "geokit", "~> 1.11"
 
-  spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake", "~> 13.0"
   spec.add_development_dependency "rspec", "~> 3.0"
   spec.add_development_dependency "pry", "~> 0.11"

--- a/geokit-geocoder-mappify.gemspec
+++ b/geokit-geocoder-mappify.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "geokit", "~> 1.11"
 
-  spec.add_development_dependency "bundler", "~> 1.16"
+  spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake", "~> 13.0"
   spec.add_development_dependency "rspec", "~> 3.0"
   spec.add_development_dependency "pry", "~> 0.11"


### PR DESCRIPTION
Because of recently published security vulnerabilities I looked into the used bundler version here. Dependabot couldn't determine the version.

Bundler doesn't manage itself with the Gemfile.lock. You can't run
`bundle update bundler`. So the version specification here doesn't mean
anything. The Gemfile.lock contains the BUNDLED WITH line which reveals
the used version though.

I also looked into my installed gems. Most have a Gemfile. But less than
half mention bundler in the gemspec. So we could go further and remove
bundler from the spec completely...

But for now I just removed the version number.