### PR TITLE
1866: Add optional debug logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Geokit::Geocoders::Mappify
 
-This is a gem to allow Geokit to work with the API from [mappify.io](https://mappify.io). It monkey-patches the Geokit code to allow both POST and GET requests.
-It currently only supports geocoding. Reverse geocoding may be added at a later date
+This is a gem to allow Geokit to work with the API from [mappify.io](https://mappify.io). It monkey-patches the Geokit code to allow both POST and GET requests, and provide debug logging. 
+It currently only supports geocoding. Reverse geocoding may be added at a later date.
 
 ## Installation
 
@@ -19,9 +19,36 @@ And then execute:
 
 The geocoder has one configuration parameter `api_key`, that can be set to your Mappify API key. If this is not specified, the anonymous tier will allow up to 100 requests/day
 
+## Usage
+
+As per GeoKit, but with additional logger option, eg:
+
+```ruby
+  Geokit::Geocoders::MappifyGeocoder.geocode(
+    street_address,
+    {
+      postCode: address.postcode,
+      suburb: address.suburb,
+      state: 'VIC',
+      logger: logger,
+    }
+  )
+
+  ...
+
+  def self.logger
+    @@my_logger ||= Logger.new("#{Rails.root}/log/geocoding_service.log")
+  end
+```
+
 ## Contributing
 
 Bug reports and pull requests are welcome on GitHub at https://github.com/[USERNAME]/geokit-geocoder-mappify.
+
+
+Tip: for local development you can try adding the following to the gemfile: `path: "/path/to/geokit-geocoder-mappify"`
+
+Or, temporarily configure a Bundler local override: `bundle config local.geokit-geocoder-mappify /path/to/geokit-geocoder-mappify`
 
 ## License
 

--- a/lib/geokit/geocoders/mappify/version.rb
+++ b/lib/geokit/geocoders/mappify/version.rb
@@ -1,7 +1,7 @@
 module Geokit
   module Geocoders
     module Mappify
-      VERSION = "0.0.1"
+      VERSION = "0.0.2"
     end
   end
 end

--- a/lib/monkeypatch/geokit/geocoders.rb
+++ b/lib/monkeypatch/geokit/geocoders.rb
@@ -2,7 +2,13 @@ module Geokit
   module Geocoders
     class Geocoder
       def self.process(format, url, *args, payload: nil)
+        logger = payload.delete(:logger)
+        logger&.debug { '[MAPPIFY PAYLOAD]  ' + payload.to_s }
+
         res = call_geocoder_service(url, payload: payload)
+        logger&.debug { '[MAPPIFY RESPONSE] ' + res.body }
+        logger&.debug { '[MAPPIFY SUMMARY]  ' + log_summary(payload, res.body).to_csv }
+
         return GeoLoc.new unless net_adapter.success?(res)
         parse format, res.body, *args
       end
@@ -16,6 +22,20 @@ module Geokit
 
       def self.do_http(url, payload:)
         payload.nil? ? net_adapter.do_get(url) : net_adapter.do_post(url, payload: payload)
+      end
+
+      private
+
+      def self.log_summary(payload, body)
+        response = JSON.parse(body)
+        [
+          "#{payload[:streetAddress]}, #{payload[:suburb]} #{payload[:state]} #{payload[:postCode]}",
+          response['result']['streetAddress'],
+          response['type'],
+          response['confidence'],
+          response['result']['location']['lat'],
+          response['result']['location']['lon'],
+        ]
       end
     end
   end


### PR DESCRIPTION
If a logger is provided, three debug messages will be logged: payload, response and a summary in csv format.

I couldn't help but document as I went.

The summary can be exported to CSV like so. (Hmm should've documented that too)

```
echo "Sent address, Received streetAddress, type, confidence, lat, lon" > log/geocoding_summary.csv
grep '\[MAPPIFY SUMMARY\]' log/geocoding_service.log | grep -o '".*' | uniq >> log/geocoding_summary.csv
```